### PR TITLE
Add documentation for configuring the container image signing

### DIFF
--- a/pipelines/signing/README.md
+++ b/pipelines/signing/README.md
@@ -1,0 +1,141 @@
+# Kabanero Container Image Signing 
+The kabanero-security repository contains sample tasks, and pipelines for signing container images built in the Kabanero pipeline. Container image signing is embedded some of the kabanero pipelines which push an image to an image registry. By default, the container image signing is not enabled. To enable image signing, review the following instructions.
+
+# About container image signing and verification
+There are several variations to assure the integrity and authenticity of the container image. Kabanero image signing follows [this standard](https://github.com/containers/image/blob/master/docs/containers-signature.5.md) which can be used for both Openshift internal image registry and external image registries.
+The container tool such as cri-o, podman or docker are capable to compute the signature of an image and prevent pulling the image into it's local registry unless the signature value matches with the original image signature value. With this functionality, it can prevent deploying un-trusted or potentially altered images in the system.
+
+# Prerequisites
+
+## Container image for image signing
+
+Kabanero-security uses [skopeo](https://github.com/containers/skopeo) for the container image signing.
+Therefore, it is required to use a container image which skopeo is available. The kabanero-pipelines are used to use [kabanero/kabanero-utils](https://hub.docker.com/r/kabanero/kabanero-utils) container image, also the same iange is used in the standaline image siging task example in this document.
+
+The first step is to create an image which is responsible to access the original image, compute signature value, then store signed image and it's signature as one of tasks of the pipeline.
+
+## Kabanero pipelines
+
+This document assumes that there is a cluster environment where [Kabanero pipelines](https://github.com/kabanero-io/kabanero-pipelines) are installed.
+
+# Configuration
+
+The following configuration steps are required:
+
+1. **Generate a key pair** - In order to sing images, a RSA key pair is required. A secret key is used for signing images, and a corresponding public key is used for verifying signed images. In here, only the secret key is used since signed image verification is out of this document.
+1. **Create a secret** - A Kubernetes secret contains the generated RSA secret and several configuration parameters.
+1. **Create a configmap** - A Kubernetes configmap contains several configuration parameters.
+
+## Generate a key pair
+### Create a batch file for generating a key pair for signing
+
+Create a file named gpg-batch and copy and paste the following contents. Make sure that Name-Real, Name-Comment, and Name-Email are modified as you like.
+
+```
+%echo Generating a default key
+Key-Type: RSA
+Key-Length: 2048
+Name-Real: <Owner name i.e., John Do>
+Name-Comment: <Any comment i.e., Signing key for kabanero>
+Name-Email: <e-mail address which is used as an id of the key  i.e., security@example.com>
+Expire-Date: 0 
+%commit
+%echo done
+``` 
+### generate a key pair
+
+If it is the first time to generate a key pair, rng-tools needs to be installed in order to generate some seed for random value.
+```
+yum install rng-tools
+rngd -r /dev/urandom
+```
+
+Run the following command for generating PGP key pair. If the passphrase input panel is displayed, press enter without setting a passphrase on for disabling the passphrase key encryption.
+```
+gpg --batch --gen-key gpg-batch
+```
+Once the key is generated, extract the public key and store it to a safe place for now. The public key is required for verifying the signature.
+```
+gpg --armor --export --output signingkey.pub <Name-Email which was used for generating the key pair>
+```
+
+## Create a secret
+
+A following secret named `image-signing-config` needs to be created to set the generated RSA secret key, the registry location where signed images are stored. A sample script is provided.
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-signing-config
+data:
+  secret.asc: <armerd secret key>
+  registry: <registry name where the signed image is stored. i.e., >
+```
+
+Modify the first few lines of `create-secret.sh` file for your environment and run the script. Make sure that you have logged in the cluster environment. This script extracts the generated RSA secret then create and apply a secret as configured. The following is an example values of the script:
+```
+#!/bin/bash
+#set namespace, signby and registry
+namespace=kabanero
+signby=security@example.com
+registry=image-registry.openshift-image-registry.svc:5000/kabanero-signed
+:
+:
+``` 
+
+## Create a configmap
+
+A following configmap named `registries-d` needs to be created to set the location where generated signatures are stored. This configuration is for the OpenShift internal image registry which supports storing the signatures by using the REST API.
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registries-d
+data:
+  default.yaml: |-
+    # This is a default registries.d configuration file.
+    # This file may be modified in order to configure the location of look aside signature store.
+    # Please refer to /etc/containers/registries.d/default.yaml file for more information.
+    default-docker:
+    # no default value in order to let skopeo push the signature to the internal docker registry.
+```
+As an example, `create-configmap.sh` is provided. Apply this file as it is if OpenShift internal image registry or an image registry which is capable of storing signatures. 
+
+Note that when the external image registry which does not support storing the signature, this configmap needs to be modified to set a persistent storage location where the signatures are stored. [This document](https://github.com/containers/image/blob/master/docs/containers-registries.d.5.md) describes how to configure registries-d file. Additionally, it might require modifying a pipeline task to mount a persistent storage to extract generated signatures.
+
+
+
+# Use stand-alone image signing pipeline
+
+A stand-alone image signing pipeline is provided as `image-signing-pipeline.yaml` which consists of sign-task and sign-pipeline. This pipeline takes two parameters as follows:
+
+* **source-image** - a source image name. i.e., docker.io/httpd.
+* **signed-image** - a signed image name. the namespace (project) name needs to match with the namespace of registry name in image-signing-config secret. i.e., image-registry.openshift-image-registry.svc:5000/kabanero-signed/httpd
+
+## Sample image signing pipeline run
+
+There is a sample script which deploys `image-signing-pipeline.yaml` and starts a sign pipeline run which pulls the latest httpd image from docker.io, sign the image, and push the image to kabanero-signed/http in the OpenShift internal image registry. This script creates kabanero-signed project for storing a signed image. After configuring a secret and configmap by running `create-secret.sh` and `create-configmap.sh`,  review and run `sample-image-signing-pipeline-run.sh`.
+You can review the progress of the pipeline run in the tekton dashboard.
+
+## Clean up the sample resources
+
+`clean-image-signing.sh` is provided for delete all of resources of the image signing which were created in this documentation.
+
+# Use image signing task from kabanero pipelines
+
+Once `image-signing-config` secret and `registries-d` configmap are created, the kabanero pipelines which run one of following tasks will sign images when an image is pushed to the image registry.
+
+* build-deploy-task
+* build-push-jk-task
+* build-push-task
+
+
+# Use image signing task from your pipeline
+
+`image-signing-pipeline.yaml`, which consists of sign-task and sign-pipeline, can be used as a template for integrating the image sign task to your pipelines.
+
+# Verifying signatures
+
+Refer to the [this document](https://developers.redhat.com/blog/2019/10/29/verifying-signatures-of-red-hat-container-images/) for verifying images with signatures.

--- a/pipelines/signing/clean-image-signing.sh
+++ b/pipelines/signing/clean-image-signing.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#set namespace
+NAMESPACE=kabanero
+
+oc -n ${NAMESPACE} delete PipelineResource/sample-source-image
+oc -n ${NAMESPACE} delete PipelineResource/sample-signed-image
+oc -n ${NAMESPACE} delete PipelineRun/sample-signing--pipeline-run
+oc -n ${NAMESPACE} delete Task/sign-task
+oc -n ${NAMESPACE} delete Pipeline/sign-pipeline
+oc -n ${NAMESPACE} delete configmap/registries-d
+oc -n ${NAMESPACE} delete secret/image-signing-config
+

--- a/pipelines/signing/create-configmap.sh
+++ b/pipelines/signing/create-configmap.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#set namespace
+namespace=kabanero
+
+cat <<EOF | oc -n ${namespace} apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registries-d
+data:
+  default.yaml: |-
+    # This is a default registries.d configuration file.
+    # This file may be modified in order to configure the location of look aside signature store.
+    # Please refer to /etc/containers/registries.d/default.yaml file for more information.
+    default-docker:
+    # no default value in order to let skopeo push the signature to the internal docker registry.
+EOF

--- a/pipelines/signing/create-secret.sh
+++ b/pipelines/signing/create-secret.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#set namespace, signby and registry
+namespace=kabanero
+signby=security@example.com
+registry=image-registry.openshift-image-registry.svc:5000/kabanero-signed
+
+cat <<EOF | oc -n ${namespace} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-signing-config
+data:
+  secret.asc: $(gpg -a --export-secret-keys ${signby} | base64 -w 0)
+  registry: $(echo $registry | base64 -w 0)
+EOF

--- a/pipelines/signing/gpg-batch
+++ b/pipelines/signing/gpg-batch
@@ -1,0 +1,9 @@
+%echo Generating a default key
+Key-Type: RSA
+Key-Length: 2048
+Name-Real: Security Person
+Name-Comment: Signing key for kabanero
+Name-Email: security@example.com
+Expire-Date: 0 
+%commit
+%echo done

--- a/pipelines/signing/image-signing-pipeline.yaml
+++ b/pipelines/signing/image-signing-pipeline.yaml
@@ -20,13 +20,13 @@ items:
       args:
         - -c
         - |
-          REPO=`cat /etc/gpg/registry`
+          REPO=`cat /image-signing-config/registry`
           if [[ $(inputs.resources.signed-image.url) != $REPO/* ]]
           then
              echo "The specified signed image repository does not match the name of the repository in image-signing-config secret resource. The repository name should start with $REPO, Specified signed image name is $(inputs.resources.signed-image.url)"
            exit 1
           fi
-          gpg --import /etc/gpg/secret.asc
+          gpg --import /image-signing-config/secret.asc
           SIGNBY=`gpg --list-keys|sed -n -e "/.*<.*>.*/p"|sed -e "s/^.*<\(.*\)>.*$/\1/"`
           skopeo copy --dest-tls-verify=false --src-tls-verify=false --remove-signatures --sign-by $SIGNBY "docker://$(inputs.resources.source-image.url)" "docker://$(inputs.resources.signed-image.url)"
           RESULT=$?
@@ -37,7 +37,7 @@ items:
           fi
       volumeMounts:
         - name: image-signing-config
-          mountPath: /etc/gpg
+          mountPath: /image-signing-config
         - name: registries-d-dir
           mountPath: /etc/containers/registries.d
     volumes:

--- a/pipelines/signing/image-signing-pipeline.yaml
+++ b/pipelines/signing/image-signing-pipeline.yaml
@@ -28,7 +28,13 @@ items:
           fi
           gpg --import /etc/gpg/secret.asc
           SIGNBY=`gpg --list-keys|sed -n -e "/.*<.*>.*/p"|sed -e "s/^.*<\(.*\)>.*$/\1/"`
-          skopeo --debug copy --dest-tls-verify=false --src-tls-verify=false --remove-signatures --sign-by $SIGNBY "docker://$(inputs.resources.source-image.url)" "docker://$(inputs.resources.signed-image.url)"
+          skopeo copy --dest-tls-verify=false --src-tls-verify=false --remove-signatures --sign-by $SIGNBY "docker://$(inputs.resources.source-image.url)" "docker://$(inputs.resources.signed-image.url)"
+          RESULT=$?
+          if [ $RESULT -ne 0 ]
+          then
+             echo "sign-image failed. exit code : $RESULT"
+             exit $RESULT
+          fi
       volumeMounts:
         - name: image-signing-config
           mountPath: /etc/gpg

--- a/pipelines/signing/image-signing-pipeline.yaml
+++ b/pipelines/signing/image-signing-pipeline.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: Task
+  metadata:
+    name: sign-task
+  spec:
+    inputs:
+      resources:
+      - name: source-image
+        type: image
+      - name: signed-image
+        type: image
+    steps:
+    - name: sign-image
+      securityContext: {}
+      image: kabanero/kabanero-utils:0.8.0
+      command: ['/bin/bash']
+      args:
+        - -c
+        - |
+          REPO=`cat /etc/gpg/registry`
+          if [[ $(inputs.resources.signed-image.url) != $REPO/* ]]
+          then
+             echo "The specified signed image repository does not match the name of the repository in image-signing-config secret resource. The repository name should start with $REPO, Specified signed image name is $(inputs.resources.signed-image.url)"
+           exit 1
+          fi
+          gpg --import /etc/gpg/secret.asc
+          SIGNBY=`gpg --list-keys|sed -n -e "/.*<.*>.*/p"|sed -e "s/^.*<\(.*\)>.*$/\1/"`
+          skopeo --debug copy --dest-tls-verify=false --src-tls-verify=false --remove-signatures --sign-by $SIGNBY "docker://$(inputs.resources.source-image.url)" "docker://$(inputs.resources.signed-image.url)"
+      volumeMounts:
+        - name: image-signing-config
+          mountPath: /etc/gpg
+        - name: registries-d-dir
+          mountPath: /etc/containers/registries.d
+    volumes:
+      - name: image-signing-config
+        secret:
+          secretName: image-signing-config
+      - name: registries-d-dir
+        configMap:
+          name: registries-d
+- apiVersion: tekton.dev/v1alpha1
+  kind: Pipeline
+  metadata:
+    name: sign-pipeline
+  spec:
+    resources:
+      - name: source-image
+        type: image
+      - name: signed-image
+        type: image
+    tasks:
+      - name: standalone-sign
+        taskRef:
+          name: sign-task
+        resources:
+          inputs:
+          - name: source-image
+            resource: source-image
+          - name: signed-image
+            resource: signed-image

--- a/pipelines/signing/sample-image-signing-pipeline-run.sh
+++ b/pipelines/signing/sample-image-signing-pipeline-run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -Eeuox pipefail
+
+### Configuration ###
+# An image to be signed #
+SOURCE_IMAGE="${SOURCE_IMAGE:-docker.io/httpd}"
+# A signed image #
+SIGNED_IMAGE="${SIGNED_IMAGE:-image-registry.openshift-image-registry.svc:5000/kabanero-signed/httpd}"
+# namespace/project where a pipeline runes
+NAMESPACE=kabanero
+# namespace/project where a generated image is stored
+NAMESPACE_SIGNED=kabanero-signed
+
+# Cleanup
+oc -n ${NAMESPACE} delete pipelinerun sample-signing--pipeline-run || true
+
+# Create a namespace to store the signed image
+echo "Creating namespace ${NAMESPACE_SIGNED}"
+oc create namespace ${NAMESPACE_SIGNED} || true
+
+oc -n ${NAMESPACE} apply -f image-signing-pipeline.yaml
+
+# Pipeline Resources: Source and signed container image
+cat <<EOF | oc -n ${NAMESPACE} apply -f -
+apiVersion: v1
+items:
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    name: sample-source-image
+  spec:
+    params:
+    - name: url
+      value: ${SOURCE_IMAGE}
+    type: image
+- apiVersion: tekton.dev/v1alpha1
+  kind: PipelineResource
+  metadata:
+    name: sample-signed-image
+  spec:
+    params:
+    - name: url
+      value: ${SIGNED_IMAGE}
+    type: image
+kind: List
+EOF
+
+# Manual Pipeline Run
+cat <<EOF | oc -n ${NAMESPACE} apply -f -
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: sample-signing--pipeline-run
+  namespace: ${NAMESPACE}
+spec:
+  pipelineRef:
+    name: sign-pipeline
+  resources:
+  - name: source-image
+    resourceRef:
+      name: sample-source-image
+  - name: signed-image
+    resourceRef:
+      name: sample-signed-image
+  serviceAccountName: kabanero-operator
+  timeout: 60m
+EOF
+


### PR DESCRIPTION
For Kabanero, only manual configuration for the container image signing is supported. Also, by default, the container image signing is not enabled. in order to enable it, image-signing-config secret and registries-d configmap need to be created. This PR covers how to create these resources and provides some scripts and yaml files as examples. 

https://github.com/kabanero-io/kabanero-pipelines/pull/316 relates to this PR.